### PR TITLE
# Выполнено ДЗ №8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Создание собственного CRD ДЗ#7
+# Мониторинг компонентов кластера и приложений, работающих в нем ДЗ#8
 
 
 ***Работы производим на WSL-Ubuntu***
@@ -13,80 +13,69 @@
 
 4) Проверяем корректность активированного ingress - kubectl get pods -n ingress-nginx
 
-5) Включаем панель для удобства - minikube addons enable dashboard
+5) В хостовую машину добавляем dns запись вида (в файл hosts) - 127.0.0.1 kubernetes.docker.internal homework.otus
 
-6) В хостовую машину добавляем dns запись вида (в файл hosts) - 127.0.0.1 kubernetes.docker.internal homework.otus
-
-
-7) Запускаем тунель - minikube tunnel
+6) Запускаем тунель - minikube tunnel
 
 
-8) Устанавливаем framework operator-sdk (Версия v1.32.0)
+## Выполнения ДЗ
 
+1) Устанавливаем prometheus-operator - helm install my-release oci://registry-1.docker.io/bitnamicharts/kube-prometheus
 
-9) Создаем виртуальное окружение для python и настраиваем его в сответствии с требованиями для operator-sdk + ansible
+2) Создаем docker image
+    - включаем модуль stab_status  
+    ```
+    location /metrics {
+        stub_status on;
+    }
+    ```
+    - **подключаем модуль/библиотеки prometheus для lua**
+    ```
+    lua_package_path "/usr/local/openresty/nginx/lualib/lib/?.lua;;";
+    lua_shared_dict prometheus_metrics 10M;
 
-## Выполнения ДЗ (*)
+    init_worker_by_lua_block {
+        prometheus = require("prometheus").init("prometheus_metrics")
+        metric_requests = prometheus:counter(
+        "nginx_http_requests_total", "Number of HTTP requests", {"host", "status"})
+        metric_latency = prometheus:histogram(
+        "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
+        metric_connections = prometheus:gauge(
+        "nginx_http_connections", "Number of HTTP connections", {"state"})
+    }
 
-1) Создаем требуемые манифестa для ДЗ
+    location /prometheus {
+        #access_log off;
 
-2) Устанавливаем и проверяем работаспособность (как с максимальными, так и с минимальными правами)
+        content_by_lua '
+            metric_connections:set(ngx.var.connections_reading, {"reading"})
+            metric_connections:set(ngx.var.connections_waiting, {"waiting"})
+            metric_connections:set(ngx.var.connections_writing, {"writing"})
+            prometheus:collect()
+        ';
+    }
 
-## Выполнения ДЗ **
-1) Создаем operator otus.homework
-```bash
-mkdir -p local
-cd local
-operator-sdk init --plugins=ansible --domain=local
-operator-sdk create api --group otus.homework --version v1 --kind MySQL --generate-role
-```
-2) Создание CRD
+    ```  
+    - Собираем образ и отправляем в публичный репозиторий -
+    ```bash
+    docker build -t nvtikhomirov/openresty-prometheus:v0.0.3 .
+    docker push nvtikhomirov/openresty-prometheus:v0.0.3    
+    ```
 
-  - **Меняем условие домашнего задания** -  Объект уровня ***Namespace*** на ***Cluster*** (scope: Namespaced - scope: Cluster). Для дальнейшего развития данного оператора и переиспользования его как шаблона.
-  - Добавляем код дз в сгенерированый шаблон(kubernetes-operators\local\config\crd\bases\otus.homework.local_mysqls.yaml):
-```yaml
-    image:
-      description: 'Определяет docker-образ для создания'
-      type: string
-    database:
-      description: 'Имя базы данных'
-      type: string
-    password:
-      description: 'Пароль от БД'
-      type: string
-    storage_size:
-      description: 'Размер хранилища под БД'
-      type: string
-```  
+3) Создаем файл deployment.yaml (nginx-prometheus-exporter собирает метрики с /metrics, готовые метрики /prometheus)
 
-3) Создаем role ansible - mysql (kubernetes-operators\local\roles\mysql)
-  - Создание namespace
-  - Создание pv и pvc
-  - Создание SA, ClusterRole и ClusterRoleBinding
-  - Создаybt Deploy
+4) Создаем service и servicemonitor.yaml
 
-4) Модифицируем шаблон crd (kubernetes-operators\local\config\crd\bases\otus.homework.local_mysqls.yaml)
+5) Для удобства создаем ingress:
 
-5) Модифицуруем шаблон role.yml (kubernetes-operators\local\config\rbac\role.yaml)
+    - /metrics (/prometheus-exporter) для работы с nginx-prometheus-exporter
 
-6) Собираем образ, пушим в репозиторий, deploy
+    - / - вывод prometheus
 
-```bash
-make docker-build IMG=nvtikhomirov/k8s-operator-otus-homework:v0.0.14
-make docker-push IMG=nvtikhomirov/k8s-operator-otus-homework:v0.0.14
-make deploy IMG=nvtikhomirov/k8s-operator-otus-homework:v0.0.14
-```
+    - /prometheus - метрики сгенерированые lua
 
-7) Применяем манифест и примера - kubectl apply -f ./config/samples/otus.homework_v1_mysql.yaml
+6) Проверка
 
-8) Производим отладку оператора (если требуется)
+    - переходим в Targets, находим ранее созданые точки мониторинга: serviceMonitor/default/custom-monitoring, serviceMonitor/default/web-monitoring (статус UP)
 
-## Научился
-1) Создавать собственные CRD и operator(ansible)
-2) Отладка оператора
-
-## Часта используемые команы
-
-kubectl logs otus-controller-manager-59d965b46f-cd96h -n otus-system -f
-
-
+    - производим выборочную проверку метрик nginx

--- a/kubernetes-monitoring/.gitignore
+++ b/kubernetes-monitoring/.gitignore
@@ -1,0 +1,1 @@
+prometheus-operator

--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework-service
+  labels:
+    app: homework-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: homework-service
+  template:
+    metadata:
+      name: homework-service
+      labels:
+        app: homework-service
+    spec:
+      containers:
+      - name: homework-service
+        image: nvtikhomirov/openresty-prometheus:v0.0.3
+        ports:
+        - name: custom-exporter
+          containerPort: 8000
+      - name: nginx-prometheus-exporter
+        image: nginx/nginx-prometheus-exporter:latest
+        args:
+          - "--nginx.scrape-uri=http://homework-service:8000/metrics/"
+        ports:
+        - name: metrics
+          containerPort: 9113
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0

--- a/kubernetes-monitoring/docker/Dockerfile
+++ b/kubernetes-monitoring/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM openresty/openresty:focal
+RUN mkdir -p /homework && mkdir -p /var/run/openresty/ && mkdir -p /usr/local/openresty/nginx/sites && groupadd -r -g 1001 openresty && useradd -r -u 1001 -g openresty openresty
+WORKDIR /homework
+RUN chown -R openresty:openresty /homework && chown -R openresty:openresty /var/run/openresty/ && chown -R openresty:openresty /usr/local/openresty/
+COPY default.conf /etc/nginx/conf.d/default.conf
+COPY prometheus.lua /usr/local/openresty/nginx/lualib/lib/prometheus.lua
+COPY prometheus_keys.lua /usr/local/openresty/nginx/lualib/lib/prometheus_keys.lua
+COPY prometheus_test.lua /usr/local/openresty/nginx/lualib/lib/prometheus_test.lua
+COPY prometheus_resty_counter.lua /usr/local/openresty/nginx/lualib/lib/prometheus_resty_counter.lua
+EXPOSE 8000
+USER openresty
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/kubernetes-monitoring/docker/default.conf
+++ b/kubernetes-monitoring/docker/default.conf
@@ -1,0 +1,53 @@
+lua_package_path "/usr/local/openresty/nginx/lualib/lib/?.lua;;";
+lua_shared_dict prometheus_metrics 10M;
+
+init_worker_by_lua_block {
+    prometheus = require("prometheus").init("prometheus_metrics")
+    metric_requests = prometheus:counter(
+    "nginx_http_requests_total", "Number of HTTP requests", {"host", "status"})
+    metric_latency = prometheus:histogram(
+    "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
+    metric_connections = prometheus:gauge(
+    "nginx_http_connections", "Number of HTTP connections", {"state"})
+}
+server {
+    listen 8000 default_server;
+    listen [::]:8000 default_server;
+
+    root /homework;
+
+    index index.html index.htm;
+
+    location / {
+        content_by_lua '
+            ngx.header["Content-type"] = "text/html; charset=utf-8"
+
+            index = "/homework/index.html"
+            local status = io.open(index, "r")
+
+            if status ~= nil then
+                html = status:read("*all")
+                ngx.say(html)
+            else
+                ngx.say("Возникла проблема с доступностью файла index.html. Вместо него произошла обработка с использованием языка программирования Lua.")
+            end
+            ngx.status = 200
+            ngx.exit(200)
+        ';
+    }
+
+    location /prometheus {
+        #access_log off;
+
+        content_by_lua '
+            metric_connections:set(ngx.var.connections_reading, {"reading"})
+            metric_connections:set(ngx.var.connections_waiting, {"waiting"})
+            metric_connections:set(ngx.var.connections_writing, {"writing"})
+            prometheus:collect()
+        ';
+    }
+
+    location /metrics {
+        stub_status on;
+    }
+}

--- a/kubernetes-monitoring/docker/prometheus.lua
+++ b/kubernetes-monitoring/docker/prometheus.lua
@@ -1,0 +1,744 @@
+--- @module Prometheus
+--
+-- vim: ts=2:sw=2:sts=2:expandtab:textwidth=80
+-- This module uses a single dictionary shared between Nginx workers to keep
+-- all metrics. Each metric is stored as a separate entry in that dictionary.
+--
+-- In addition, each worker process has a separate set of counters within
+-- its lua runtime that are used to track increments to counte metrics, and
+-- are regularly flushed into the main shared dictionary. This is a performance
+-- optimization that allows counters to be incremented without locking the
+-- shared dictionary. It also means that counter increments are "eventually
+-- consistent"; it can take up to a single counter sync interval (which
+-- defaults to 1 second) for counter values to be visible for collection.
+--
+-- Prometheus requires that (a) all samples for a given metric are presented
+-- as one uninterrupted group, and (b) buckets of a histogram appear in
+-- increasing numerical order. We satisfy that by carefully constructing full
+-- metric names (i.e. metric name along with all labels) so that they meet
+-- those requirements while being sorted alphabetically. In particular:
+--
+--  * all labels for a given metric are presented in reproducible order (the one
+--    used when labels were declared). "le" label for histogram metrics always
+--    goes last;
+--  * bucket boundaries (which are exposed as values of the "le" label) are
+--    presented as floating point numbers with leading and trailing zeroes.
+--    Number of of zeroes is determined for each bucketer automatically based on
+--    bucket boundaries;
+--  * internally "+Inf" bucket is stored as "Inf" (to make it appear after
+--    all numeric buckets), and gets replaced by "+Inf" just before we
+--    expose the metrics.
+--
+-- For example, if you define your bucket boundaries as {0.00005, 10, 1000}
+-- then we will keep the following samples for a metric `m1` with label
+-- `site` set to `site1`:
+--
+--   m1_bucket{site="site1",le="0000.00005"}
+--   m1_bucket{site="site1",le="0010.00000"}
+--   m1_bucket{site="site1",le="1000.00000"}
+--   m1_bucket{site="site1",le="Inf"}
+--   m1_count{site="site1"}
+--   m1_sum{site="site1"}
+--
+-- "Inf" will be replaced by "+Inf" while publishing metrics.
+--
+-- You can find the latest version and documentation at
+-- https://github.com/knyar/nginx-lua-prometheus
+-- Released under MIT license.
+
+-- This library provides per-worker counters used to store counter metric
+-- increments. Copied from https://github.com/Kong/lua-resty-counter
+local resty_counter_lib = require("prometheus_resty_counter")
+local key_index_lib = require("prometheus_keys")
+
+local Prometheus = {}
+local mt = { __index = Prometheus }
+
+local TYPE_COUNTER    = 0x1
+local TYPE_GAUGE      = 0x2
+local TYPE_HISTOGRAM  = 0x4
+local TYPE_LITERAL = {
+  [TYPE_COUNTER]   = "counter",
+  [TYPE_GAUGE]     = "gauge",
+  [TYPE_HISTOGRAM] = "histogram",
+}
+
+-- Default name for error metric incremented by this library.
+local DEFAULT_ERROR_METRIC_NAME = "nginx_metric_errors_total"
+
+-- Default value for per-worker counter sync interval (seconds).
+local DEFAULT_SYNC_INTERVAL = 1
+
+-- Default set of latency buckets, 5ms to 10s:
+local DEFAULT_BUCKETS = {0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.2, 0.3,
+                         0.4, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5, 10}
+
+-- Prefix for internal shared dictionary items.
+local KEY_INDEX_PREFIX = "__ngx_prom__"
+
+-- Generate full metric name that includes all labels.
+--
+-- Args:
+--   name: string
+--   label_names: (array) a list of label keys.
+--   label_values: (array) a list of label values.
+-- Returns:
+--   (string) full metric name.
+local function full_metric_name(name, label_names, label_values)
+  if not label_names then
+    return name
+  end
+  local label_parts = {}
+  for idx, key in ipairs(label_names) do
+    local label_value = (string.format("%s", label_values[idx])
+      :gsub("[^\032-\126]", "")  -- strip non-printable characters
+      :gsub("\\", "\\\\")
+      :gsub('"', '\\"'))
+    table.insert(label_parts, key .. '="' .. label_value .. '"')
+  end
+  return name .. "{" .. table.concat(label_parts, ",") .. "}"
+end
+
+-- Extract short metric name from the full one.
+--
+-- This function is only used by Prometheus:metric_data.
+--
+-- Args:
+--   full_name: (string) full metric name that can include labels.
+--
+-- Returns:
+--   (string) short metric name with no labels. For a `*_bucket` metric of
+--     histogram the _bucket suffix will be removed.
+local function short_metric_name(full_name)
+  local labels_start, _ = full_name:find("{")
+  if not labels_start then
+    return full_name
+  end
+  -- Try to detect if this is a histogram metric. We only check for the
+  -- `_bucket` suffix here, since it alphabetically goes before other
+  -- histogram suffixes (`_count` and `_sum`).
+  local suffix_idx, _ = full_name:find("_bucket{")
+  if suffix_idx and full_name:find("le=") then
+    -- this is a histogram metric
+    return full_name:sub(1, suffix_idx - 1)
+  end
+  -- this is not a histogram metric
+  return full_name:sub(1, labels_start - 1)
+end
+
+-- Check metric name and label names for correctness.
+--
+-- Regular expressions to validate metric and label names are
+-- documented in https://prometheus.io/docs/concepts/data_model/
+--
+-- Args:
+--   metric_name: (string) metric name.
+--   label_names: label names (array of strings).
+--
+-- Returns:
+--   Either an error string, or nil of no errors were found.
+local function check_metric_and_label_names(metric_name, label_names)
+  if not metric_name:match("^[a-zA-Z_:][a-zA-Z0-9_:]*$") then
+    return "Metric name '" .. metric_name .. "' is invalid"
+  end
+  if metric_name:find(KEY_INDEX_PREFIX) == 1 then
+    return "Prefix '" .. KEY_INDEX_PREFIX .. "' is reserved for internal purposes"
+  end
+  for _, label_name in ipairs(label_names or {}) do
+    if label_name == "le" then
+      return "Invalid label name 'le' in " .. metric_name
+    end
+    if not label_name:match("^[a-zA-Z_][a-zA-Z0-9_]*$") then
+      return "Metric '" .. metric_name .. "' label name '" .. label_name ..
+             "' is invalid"
+    end
+  end
+end
+
+-- Construct bucket format for a list of buckets.
+--
+-- This receives a list of buckets and returns a sprintf template that should
+-- be used for bucket boundaries to make them come in increasing order when
+-- sorted alphabetically.
+--
+-- To re-phrase, this is where we detect how many leading and trailing zeros we
+-- need.
+--
+-- Args:
+--   buckets: a list of buckets
+--
+-- Returns:
+--   (string) a sprintf template.
+local function construct_bucket_format(buckets)
+  local max_order = 1
+  local max_precision = 1
+  for _, bucket in ipairs(buckets) do
+    assert(type(bucket) == "number", "bucket boundaries should be numeric")
+    -- floating point number with all trailing zeros removed
+    local as_string = string.format("%f", bucket):gsub("0*$", "")
+    local dot_idx = as_string:find(".", 1, true)
+    max_order = math.max(max_order, dot_idx - 1)
+    max_precision = math.max(max_precision, as_string:len() - dot_idx)
+  end
+  return "%0" .. (max_order + max_precision + 1) .. "." .. max_precision .. "f"
+end
+
+-- Return a full metric name for a given metric+label combination.
+--
+-- This function calculates a full metric name (or, in case of a histogram
+-- metric, several metric names) for a given combination of label values. It
+-- stores the result in a tree of tables used as a cache (self.lookup) and
+-- uses that cache to return results faster.
+--
+-- Args:
+--   self: a `metric` object, created by register().
+--   label_values: a list of label values.
+--
+-- Returns:
+--   - If `self` is a counter or a gauge: full metric name as a string.
+--   - If `self` is a histogram metric: a list of strings:
+--     [0]: full name of the _count histogram metric;
+--     [1]: full name of the _sum histogram metric;
+--     [...]: full names of each _bucket metrics.
+local function lookup_or_create(self, label_values)
+  -- If one of the `label_values` is nil, #label_values will return the number
+  -- of non-nil labels in the beginning of the list. This will make us return an
+  -- error here as well.
+  local cnt = label_values and #label_values or 0
+  -- specially, if first element is nil, # will treat it as "non-empty"
+  if cnt ~= self.label_count or (self.label_count > 0 and not label_values[1]) then
+    return nil, string.format("inconsistent labels count, expected %d, got %d",
+                              self.label_count, cnt)
+  end
+  local t = self.lookup
+  if label_values then
+    -- Don't use ipairs here to avoid inner loop generates trace first
+    -- Otherwise the inner for loop below is likely to get JIT compiled before
+    -- the outer loop which include `lookup_or_create`, in this case the trace
+    -- for outer loop will be aborted. By not using ipairs, we will be able to
+    -- compile longer traces as possible.
+    local label
+    for i=1, self.label_count do
+      label = label_values[i]
+      if not t[label] then
+        t[label] = {}
+      end
+      t = t[label]
+    end
+  end
+
+  local LEAF_KEY = mt -- key used to store full metric names in leaf tables.
+  local full_name = t[LEAF_KEY]
+  if full_name then
+    return full_name
+  end
+
+  if self.typ == TYPE_HISTOGRAM then
+    -- Pass empty metric name to full_metric_name to just get the formatted
+    -- labels ({key1="value1",key2="value2",...}).
+    local labels = full_metric_name("", self.label_names, label_values)
+    full_name = {
+      self.name .. "_count" .. labels,
+      self.name .. "_sum" .. labels,
+    }
+
+    local bucket_pref
+    if self.label_count > 0 then
+      -- strip last }
+      bucket_pref = self.name .. "_bucket" .. string.sub(labels, 1, #labels-1) .. ","
+    else
+      bucket_pref = self.name .. "_bucket{"
+    end
+
+    for i, buc in ipairs(self.buckets) do
+      full_name[i+2] = string.format("%sle=\"%s\"}", bucket_pref, self.bucket_format:format(buc))
+    end
+    -- Last bucket. Note, that the label value is "Inf" rather than "+Inf"
+    -- required by Prometheus. This is necessary for this bucket to be the last
+    -- one when all metrics are lexicographically sorted. "Inf" will get replaced
+    -- by "+Inf" in Prometheus:metric_data().
+    full_name[self.bucket_count+3] = string.format("%sle=\"Inf\"}", bucket_pref)
+  else
+    full_name = full_metric_name(self.name, self.label_names, label_values)
+  end
+  t[LEAF_KEY] = full_name
+  local err = self._key_index:add(full_name)
+  if err then
+    return nil, err
+  end
+  return full_name
+end
+
+-- Increment a gauge metric.
+--
+-- Gauges are incremented in the dictionary directly to provide strong ordering
+-- of inc() and set() operations.
+--
+-- Args:
+--   self: a `metric` object, created by register().
+--   value: numeric value to increment by. Can be negative.
+--   label_values: a list of label values, in the same order as label keys.
+local function inc_gauge(self, value, label_values)
+  local k, err, _
+  k, err = lookup_or_create(self, label_values)
+  if err then
+    self._log_error(err)
+    return
+  end
+
+  _, err, _ = self._dict:incr(k, value, 0)
+  if err then
+    self._log_error_kv(k, value, err)
+  end
+end
+
+local ERR_MSG_COUNTER_NOT_INITIALIZED = "counter not initialized! " ..
+  "Have you called Prometheus:init() from the " ..
+  "init_worker_by_lua_block nginx phase?"
+
+-- Increment a counter metric.
+--
+-- Counters are incremented in the per-worker counter, which will eventually get
+-- flushed into the global shared dictionary.
+--
+-- Args:
+--   self: a `metric` object, created by register().
+--   value: numeric value to increment by. Can't be negative.
+--   label_values: a list of label values, in the same order as label keys.
+local function inc_counter(self, value, label_values)
+  -- counter is not allowed to decrease
+  if value and value < 0 then
+    self._log_error_kv(self.name, value, "Value should not be negative")
+    return
+  end
+
+  local k, err
+  k, err = lookup_or_create(self, label_values)
+  if err then
+    self._log_error(err)
+    return
+  end
+
+  local c = self._counter
+  if not c then
+    c = self.parent._counter
+    if not c then
+      self._log_error(ERR_MSG_COUNTER_NOT_INITIALIZED)
+      return
+    end
+    self._counter = c
+  end
+  c:incr(k, value)
+end
+
+-- Delete a counter or a gauge metric.
+--
+-- Args:
+--   self: a `metric` object, created by register().
+--   label_values: a list of label values, in the same order as label keys.
+local function del(self, label_values)
+  local k, _, err
+  k, err = lookup_or_create(self, label_values)
+  if err then
+    self._log_error(err)
+    return
+  end
+
+  -- `del` might be called immediately after a configuration change that stops a
+  -- given metric from being used, so we cannot guarantee that other workers
+  -- don't have unflushed counter values for a metric that is about to be
+  -- deleted. We wait for `sync_interval` here to ensure that those values are
+  -- synced (and deleted from worker-local counters) before a given metric is
+  -- removed.
+  -- Gauge metrics don't use per-worker counters, so for gauges we don't need to
+  -- wait for the counter to sync.
+  if self.typ ~= TYPE_GAUGE then
+    ngx.log(ngx.INFO, "waiting ", self.parent.sync_interval, "s for counter to sync")
+    ngx.sleep(self.parent.sync_interval)
+  end
+
+  self._key_index:remove(k)
+  _, err = self._dict:delete(k)
+  if err then
+    self._log_error("Error deleting key: ".. k .. ": " .. err)
+  end
+end
+
+-- Set the value of a gauge metric.
+--
+-- Args:
+--   self: a `metric` object, created by register().
+--   value: numeric value.
+--   label_values: a list of label values, in the same order as label keys.
+local function set(self, value, label_values)
+  if not value then
+    self._log_error("No value passed for " .. self.name)
+    return
+  end
+
+  local k, _, err
+  k, err = lookup_or_create(self, label_values)
+  if err then
+    self._log_error(err)
+    return
+  end
+  _, err = self._dict:safe_set(k, value)
+  if err then
+    self._log_error_kv(k, value, err)
+  end
+end
+
+-- Record a given value in a histogram.
+--
+-- Args:
+--   self: a `metric` object, created by register().
+--   value: numeric value to record. Should be defined.
+--   label_values: a list of label values, in the same order as label keys.
+local function observe(self, value, label_values)
+  if not value then
+    self._log_error("No value passed for " .. self.name)
+    return
+  end
+
+  local keys, err = lookup_or_create(self, label_values)
+  if err then
+    self._log_error(err)
+    return
+  end
+
+  local c = self._counter
+  if not c then
+    c = self.parent._counter
+    if not c then
+      self._log_error(ERR_MSG_COUNTER_NOT_INITIALIZED)
+      return
+    end
+    self._counter = c
+  end
+
+  -- _count metric.
+  c:incr(keys[1], 1)
+
+  -- _sum metric.
+  c:incr(keys[2], value)
+
+  local seen = false
+  -- check in reverse order, otherwise we will always
+  -- need to traverse the whole table.
+  for i=self.bucket_count, 1, -1 do
+    if value <= self.buckets[i] then
+      c:incr(keys[2+i], 1)
+      seen = true
+    elseif seen then
+      break
+    end
+  end
+  -- the last bucket (le="Inf").
+  c:incr(keys[self.bucket_count+3], 1)
+end
+
+-- Delete all metrics for a given gauge or a counter.
+--
+-- This is like `del`, but will delete all time series for all previously
+-- recorded label values.
+--
+-- Args:
+--   self: a `metric` object, created by register().
+local function reset(self)
+  -- Wait for other worker threads to sync their counters before removing the
+  -- metric (please see `del` for a more detailed comment).
+  -- Gauge metrics don't use per-worker counters, so for gauges we don't need to
+  -- wait for the counter to sync.
+  if self.typ ~= TYPE_GAUGE then
+    ngx.log(ngx.INFO, "waiting ", self.parent.sync_interval, "s for counter to sync")
+    ngx.sleep(self.parent.sync_interval)
+  end
+
+  local keys = self._key_index:list()
+  local name_prefix = self.name .. "{"
+  local name_prefix_length = #name_prefix
+
+  for _, key in ipairs(keys) do
+    local value, key_err = self._dict:get(key)
+    if value then
+      -- without labels equal, or with labels and the part before { equals
+      if key == self.name or name_prefix == string.sub(key, 1, name_prefix_length) then
+        self._key_index:remove(key)
+        local _, err = self._dict:safe_set(key, nil)
+        if err then
+          self._log_error("Error resetting '", key, "': ", err)
+        end
+      end
+    else
+      if type(key_err) == "string" then
+        self._log_error("Error getting '", key, "': ", key_err)
+      end
+    end
+  end
+
+  -- Clean up the full metric name lookup table as well.
+  self.lookup = {}
+end
+
+-- Initialize the module.
+--
+-- This should be called once from the `init_by_lua` section in nginx
+-- configuration.
+--
+-- Args:
+--   dict_name: (string) name of the nginx shared dictionary which will be
+--     used to store all metrics
+--   prefix: (optional string) if supplied, prefix is added to all
+--     metric names on output
+--
+-- Returns:
+--   an object that should be used to register metrics.
+function Prometheus.init(dict_name, options_or_prefix)
+  if ngx.get_phase() ~= 'init' and ngx.get_phase() ~= 'init_worker' then
+    error('Prometheus.init can only be called from ' ..
+      'init_by_lua_block or init_worker_by_lua_block', 2)
+  end
+
+  local self = setmetatable({}, mt)
+  dict_name = dict_name or "prometheus_metrics"
+  self.dict_name = dict_name
+  self.dict = ngx.shared[dict_name]
+  if self.dict == nil then
+    error("Dictionary '" .. dict_name .. "' does not seem to exist. " ..
+      "Please define the dictionary using `lua_shared_dict`.", 2)
+  end
+
+  if type(options_or_prefix) == "table" then
+    self.prefix = options_or_prefix.prefix or ''
+    self.error_metric_name = options_or_prefix.error_metric_name or
+      DEFAULT_ERROR_METRIC_NAME
+    self.sync_interval = options_or_prefix.sync_interval or
+      DEFAULT_SYNC_INTERVAL
+  else
+    self.prefix = options_or_prefix or ''
+    self.error_metric_name = DEFAULT_ERROR_METRIC_NAME
+    self.sync_interval = DEFAULT_SYNC_INTERVAL
+  end
+
+  self.registry = {}
+  self.key_index = key_index_lib.new(self.dict, KEY_INDEX_PREFIX)
+
+  self.initialized = true
+
+  self:counter(self.error_metric_name, "Number of nginx-lua-prometheus errors")
+  self.dict:set(self.error_metric_name, 0)
+  local err = self.key_index:add(self.error_metric_name)
+  if err then
+    self:log_error(err)
+  end
+
+  if ngx.get_phase() == 'init_worker' then
+    self:init_worker(self.sync_interval)
+  end
+  return self
+end
+
+-- Initialize the worker counter.
+--
+-- This can call this function from the `init_worker_by_lua` if you are calling
+-- Prometheus.init() from `init_by_lua`, but this is deprecated. Instead, just
+-- call Prometheus.init() from `init_worker_by_lua_block` and pass sync_interval
+-- as part of the `options` argument if you need.
+--
+-- Args:
+--   sync_interval: per-worker counter sync interval (in seconds).
+function Prometheus:init_worker(sync_interval)
+  if ngx.get_phase() ~= 'init_worker' then
+    error('Prometheus:init_worker can only be called in ' ..
+      'init_worker_by_lua_block', 2)
+  end
+  if self._counter then
+    ngx.log(ngx.WARN, 'init_worker() has been called twice. ' ..
+      'Please do not explicitly call init_worker. ' ..
+      'Instead, call Prometheus:init() in the init_worker_by_lua_block')
+    return
+  end
+  self.sync_interval = sync_interval or DEFAULT_SYNC_INTERVAL
+  local counter_instance, err = resty_counter_lib.new(
+      self.dict_name, self.sync_interval)
+  if err then
+    error(err, 2)
+  end
+  self._counter = counter_instance
+end
+
+-- Register a new metric.
+--
+-- Args:
+--   self: a Prometheus object.
+--   name: (string) name of the metric. Required.
+--   help: (string) description of the metric. Will be used for the HELP
+--     comment on the metrics page. Optional.
+--   label_names: array of strings, defining a list of metrics. Optional.
+--   buckets: array if numbers, defining bucket boundaries. Only used for
+--     histogram metrics.
+--   typ: metric type (one of the TYPE_* constants).
+--
+-- Returns:
+--   a new metric object.
+local function register(self, name, help, label_names, buckets, typ)
+  if not self.initialized then
+    ngx.log(ngx.ERR, "Prometheus module has not been initialized")
+    return
+  end
+
+  local err = check_metric_and_label_names(name, label_names)
+  if err then
+    self:log_error(err)
+    return
+  end
+
+  local name_maybe_historgram = name:gsub("_bucket$", "")
+                                    :gsub("_count$", "")
+                                    :gsub("_sum$", "")
+  if (typ ~= TYPE_HISTOGRAM and (
+      self.registry[name] or self.registry[name_maybe_historgram]
+    )) or
+    (typ == TYPE_HISTOGRAM and (
+      self.registry[name] or
+      self.registry[name .. "_count"] or
+      self.registry[name .. "_sum"] or self.registry[name .. "_bucket"]
+    )) then
+
+    self:log_error("Duplicate metric " .. name)
+    return
+  end
+
+  local metric = {
+    name = name,
+    help = help,
+    typ = typ,
+    label_names = label_names,
+    label_count = label_names and #label_names or 0,
+    -- Lookup is a tree of lua tables that contain label values, with leaf
+    -- tables containing full metric names. For example, given a metric
+    -- `http_count` and labels `host` and `status`, it might contain the
+    -- following values:
+    -- ['me.com']['200'][LEAF_KEY] = 'http_count{host="me.com",status="200"}'
+    -- ['me.com']['500'][LEAF_KEY] = 'http_count{host="me.com",status="500"}'
+    -- ['my.net']['200'][LEAF_KEY] = 'http_count{host="my.net",status="200"}'
+    -- ['my.net']['500'][LEAF_KEY] = 'http_count{host="my.net",status="500"}'
+    lookup = {},
+    parent = self,
+    -- Store a reference for logging functions for faster lookup.
+    _log_error = function(...) self:log_error(...) end,
+    _log_error_kv = function(...) self:log_error_kv(...) end,
+    _key_index = self.key_index,
+    _dict = self.dict,
+  }
+  if typ < TYPE_HISTOGRAM then
+    if typ == TYPE_GAUGE then
+      metric.set = set
+      metric.inc = inc_gauge
+    else
+      metric.inc = inc_counter
+    end
+    metric.reset = reset
+    metric.del = del
+  else
+    metric.observe = observe
+    metric.buckets = buckets or DEFAULT_BUCKETS
+    metric.bucket_count = #metric.buckets
+    metric.bucket_format = construct_bucket_format(metric.buckets)
+  end
+
+  self.registry[name] = metric
+  return metric
+end
+
+-- Public function to register a counter.
+function Prometheus:counter(name, help, label_names)
+  return register(self, name, help, label_names, nil, TYPE_COUNTER)
+end
+
+-- Public function to register a gauge.
+function Prometheus:gauge(name, help, label_names)
+  return register(self, name, help, label_names, nil, TYPE_GAUGE)
+end
+
+-- Public function to register a histogram.
+function Prometheus:histogram(name, help, label_names, buckets)
+  return register(self, name, help, label_names, buckets, TYPE_HISTOGRAM)
+end
+
+-- Prometheus compatible metric data as an array of strings.
+--
+-- Returns:
+--   Array of strings with all metrics in a text format compatible with
+--   Prometheus.
+function Prometheus:metric_data()
+  if not self.initialized then
+    ngx.log(ngx.ERR, "Prometheus module has not been initialized")
+    return
+  end
+
+  -- Force a manual sync of counter local state (mostly to make tests work).
+  self._counter:sync()
+
+  local keys = self.key_index:list()
+  -- Prometheus server expects buckets of a histogram to appear in increasing
+  -- numerical order of their label values.
+  table.sort(keys)
+
+  local seen_metrics = {}
+  local output = {}
+  for _, key in ipairs(keys) do
+    local value, err = self.dict:get(key)
+    if value then
+      local short_name = short_metric_name(key)
+      if not seen_metrics[short_name] then
+        local m = self.registry[short_name]
+        if m then
+          if m.help then
+            table.insert(output, string.format("# HELP %s%s %s\n",
+            self.prefix, short_name, m.help))
+          end
+          if m.typ then
+            table.insert(output, string.format("# TYPE %s%s %s\n",
+              self.prefix, short_name, TYPE_LITERAL[m.typ]))
+          end
+        end
+        seen_metrics[short_name] = true
+      end
+      -- Replace "Inf" with "+Inf" in each metric's last bucket 'le' label.
+      if key:find('le="Inf"', 1, true) then
+        key = key:gsub('le="Inf"', 'le="+Inf"')
+      end
+      table.insert(output, string.format("%s%s %s\n", self.prefix, key, value))
+    else
+      if type(err) == "string" then
+        self:log_error("Error getting '", key, "': ", err)
+      end
+    end
+  end
+  return output
+end
+
+-- Present all metrics in a text format compatible with Prometheus.
+--
+-- This function should be used to expose the metrics on a separate HTTP page.
+-- It will get the metrics from the dictionary, sort them, and expose them
+-- aling with TYPE and HELP comments.
+function Prometheus:collect()
+  ngx.header.content_type = "text/plain"
+  ngx.print(self:metric_data())
+end
+
+-- Log an error, incrementing the error counter.
+function Prometheus:log_error(...)
+  ngx.log(ngx.ERR, ...)
+  self.dict:incr(self.error_metric_name, 1, 0)
+end
+
+-- Log an error that happened while setting up a dictionary key.
+function Prometheus:log_error_kv(key, value, err)
+  self:log_error(
+    "Error while setting '", key, "' to '", value, "': '", err, "'")
+end
+
+return Prometheus

--- a/kubernetes-monitoring/docker/prometheus_keys.lua
+++ b/kubernetes-monitoring/docker/prometheus_keys.lua
@@ -1,0 +1,119 @@
+-- Storage to keep track of used keys. Allows to atomically create, delete
+-- and list keys. The keys are synchronized between nginx workers
+-- using ngx.shared.dict. The whole purpose of this module is to avoid
+-- using ngx.shared.dict:get_keys (see https://github.com/openresty/lua-nginx-module#ngxshareddictget_keys),
+-- which blocks all workers and therefore it shouldn't be used with large
+-- amounts of keys.
+
+local KeyIndex = {}
+KeyIndex.__index = KeyIndex
+
+function KeyIndex.new(shared_dict, prefix)
+  local self = setmetatable({}, KeyIndex)
+  self.dict = shared_dict
+  self.key_prefix = prefix .. "key_"
+  self.delete_count = prefix .. "delete_count"
+  self.key_count = prefix .. "key_count"
+  self.last = 0
+  self.deleted = 0
+  self.keys = {}
+  self.index = {}
+  return self
+end
+
+-- Loads new keys that might have been added by other workers since last sync.
+function KeyIndex:sync()
+  local delete_count = self.dict:get(self.delete_count) or 0
+  local N = self.dict:get(self.key_count) or 0
+  if self.deleted ~= delete_count then
+    -- Some other worker deleted something, lets do a full sync.
+    self:sync_range(0, N)
+    self.deleted = delete_count
+  elseif N ~= self.last then
+    -- Sync only new keys, if there are any.
+    self:sync_range(self.last, N)
+  end
+  return N
+end
+
+-- Iterates keys from first to last, adds new items and removes deleted items.
+function KeyIndex:sync_range(first, last)
+  for i = first, last do
+    -- Read i-th key. If it is nil, it means it was deleted by some other thread.
+    local key = self.dict:get(self.key_prefix .. i)
+    if key then
+      self.keys[i] = key
+      self.index[key] = i
+    elseif self.keys[i] then
+      self.index[self.keys[i]] = nil
+      self.keys[i] = nil
+    end
+  end
+  self.last = last
+end
+
+-- Returns array of all keys.
+function KeyIndex:list()
+  self:sync()
+  local copy = {}
+  local i = 1
+  for _, v in pairs(self.keys) do
+    copy[i] = v
+    i = i + 1
+  end
+  return copy
+end
+
+-- Atomically adds one or more keys to the index.
+--
+-- Args:
+--   key_or_keys: Single string or a list of strings containing keys to add.
+--
+-- Returns:
+--   nil on success, string with error message otherwise
+function KeyIndex:add(key_or_keys)
+  local keys = key_or_keys
+  if type(key_or_keys) == "string" then
+    keys = { key_or_keys }
+  end
+
+  for _, key in pairs(keys) do
+    while true do
+      local N = self:sync()
+      if self.index[key] ~= nil then
+        -- key already exists, we can skip it
+        break
+      end
+      N = N+1
+      local ok, err = self.dict:safe_add(self.key_prefix .. N, key)
+      if ok then
+        self.dict:incr(self.key_count, 1, 0)
+        self.keys[N] = key
+        self.index[key] = N
+        break
+      elseif err ~= "exists" then
+        return "Unexpected error adding a key: " .. err
+      end
+    end
+  end
+end
+
+-- Removes a key based on its value.
+--
+-- Args:
+--   key: String value of the key, must exists in this index.
+function KeyIndex:remove(key)
+  local i = self.index[key]
+  if i then
+    self.index[key] = nil
+    self.keys[i] = nil
+    self.dict:safe_set(self.key_prefix .. i, nil)
+    -- increment delete_count to signalize other workers that they should do a full sync
+    self.dict:incr(self.delete_count, 1, 0)
+    self.deleted = self.deleted + 1
+  else
+    ngx.log(ngx.ERR, "Trying to remove non-existent key: ", key)
+  end
+end
+
+return KeyIndex

--- a/kubernetes-monitoring/docker/prometheus_resty_counter.lua
+++ b/kubernetes-monitoring/docker/prometheus_resty_counter.lua
@@ -1,0 +1,109 @@
+local ngx_shared = ngx.shared
+local pairs = pairs
+local ngx = ngx
+local error = error
+local setmetatable = setmetatable
+local tonumber = tonumber
+
+local clear_tab
+do
+  local ok
+  ok, clear_tab = pcall(require, "table.clear")
+  if not ok then
+    clear_tab = function(tab)
+      for k in pairs(tab) do
+        tab[k] = nil
+      end
+    end
+  end
+end
+
+local _M = {
+  _VERSION = '0.2.1'
+}
+local mt = { __index = _M }
+
+-- local cache of counters increments
+local increments = {}
+-- boolean flags of per worker sync timers
+local timer_started = {}
+
+local id
+
+local function sync(_, self)
+  local err, _
+  local ok = true
+  for k, v in pairs(self.increments) do
+    _, err, _ = self.dict:incr(k, v, 0)
+    if err then
+      ngx.log(ngx.WARN, "error increasing counter in shdict key: ", k, ", err: ", err)
+      ok = false
+    end
+  end
+
+  clear_tab(self.increments)
+  return ok
+end
+
+function _M.new(shdict_name, sync_interval)
+  id = ngx.worker.id()
+
+  if not ngx_shared[shdict_name] then
+    error("shared dict \"" .. (shdict_name or "nil") .. "\" not defined", 2)
+  end
+
+  if not increments[shdict_name] then
+    increments[shdict_name] = {}
+  end
+
+  local self = setmetatable({
+    dict = ngx_shared[shdict_name],
+    increments = increments[shdict_name],
+  }, mt)
+
+  if sync_interval then
+    sync_interval = tonumber(sync_interval)
+    if not sync_interval or sync_interval < 0 then
+      error("expect sync_interval to be a positive number", 2)
+    end
+    if not timer_started[shdict_name] then
+      ngx.log(ngx.DEBUG, "start timer for shdict ", shdict_name, " on worker ", id)
+      ngx.timer.every(sync_interval, sync, self)
+      timer_started[shdict_name] = true
+    end
+  end
+
+  return self
+end
+
+function _M:sync()
+  return sync(false, self)
+end
+
+function _M:incr(key, step)
+  step = step or 1
+  local v = self.increments[key]
+  if v then
+    step = step + v
+  end
+
+  self.increments[key] = step
+  return true
+end
+
+function _M:reset(key, number)
+  if not number then
+    return nil, "expect a number at #2"
+  end
+  return self.dict:incr(key, -number, number)
+end
+
+function _M:get(key)
+  return self.dict:get(key)
+end
+
+function _M:get_keys(max_count)
+  return self.dict:get_keys(max_count)
+end
+
+return _M

--- a/kubernetes-monitoring/docker/prometheus_test.lua
+++ b/kubernetes-monitoring/docker/prometheus_test.lua
@@ -1,0 +1,688 @@
+-- vim: ts=2:sw=2:sts=2:expandtab
+luaunit = require('luaunit')
+
+-- Simple implementation of a nginx shared dictionary
+local SimpleDict = {}
+SimpleDict.__index = SimpleDict
+function SimpleDict:set(k, v)
+  if not self.dict then self.dict = {} end
+  self.dict[k] = v
+  return true, nil, false  -- success, err, forcible
+end
+function SimpleDict:safe_set(k, v)
+  self:set(k, v)
+  return true, nil  -- ok, err
+end
+function SimpleDict:safe_add(k, v)
+  if k == "willnotfit" or v == "willnotfit" then
+    return nil, "no memory"
+  end
+  self:set(k, v)
+  return true, nil  -- ok, err
+end
+function SimpleDict:incr(k, v, init)
+  if k:find("willnotfit") then
+    return nil, "no memory"
+  end
+  if not self.dict[k] then self.dict[k] = init end
+  self.dict[k] = self.dict[k] + (v or 1)
+  return self.dict[k], nil  -- newval, err
+end
+function SimpleDict:get(k)
+  -- simulate key not exist
+  if k == "gauge2{f2=\"key_not_exist\",f1=\"key_not_exist\"}" then
+    return nil, nil
+  end
+  -- simulate an error
+  if k == "gauge2{f2=\"dict_error\",f1=\"dict_error\"}" then
+    return nil, "dict error"
+  end
+  if not self.dict then self.dict = {} end
+  return self.dict[k], nil  -- value, err
+end
+function SimpleDict:delete(k)
+  self.dict[k] = nil
+end
+
+-- Global nginx object
+local Nginx = {}
+Nginx.__index = Nginx
+Nginx.ERR = {}
+Nginx.WARN = {}
+Nginx.DEBUG = {}
+Nginx.header = {}
+function Nginx.log(level, ...)
+  if level == ngx.DEBUG then return end
+  if not ngx.logs then ngx.logs = {} end
+  table.insert(ngx.logs, table.concat({...}, " "))
+end
+function Nginx.print(printed)
+  if not ngx.printed then ngx.printed = {} end
+  for str in string.gmatch(table.concat(printed, ""), "([^\n]+)") do
+    table.insert(ngx.printed, str)
+  end
+end
+Nginx.worker = {}
+function Nginx.worker.id()
+  return 'testworker'
+end
+function Nginx.sleep() end
+Nginx.timer = {}
+function Nginx.timer.every(_, _, _) end
+function Nginx.get_phase()
+  return 'init_worker'
+end
+
+ngx = setmetatable({shared={}}, Nginx)
+
+-- Finds index of a given object in a table
+local function find_idx(table, element)
+  for idx, value in pairs(table) do
+    if value == element then
+      return idx
+    end
+  end
+end
+
+TestPrometheus = {}
+function TestPrometheus:setUp()
+  self.dict = setmetatable({}, SimpleDict)
+  ngx.shared.metrics = self.dict
+  self.p = require('prometheus').init('metrics')
+  self.counter1 = self.p:counter("metric1", "Metric 1")
+  self.counter2 = self.p:counter("metric2", "Metric 2", {"f2", "f1"})
+  self.counter3 = self.p:counter("metric3", "Metric 3", {"f3"})
+  self.gauge1 = self.p:gauge("gauge1", "Gauge 1")
+  self.gauge2 = self.p:gauge("gauge2", "Gauge 2", {"f2", "f1"})
+  self.hist1 = self.p:histogram("l1", "Histogram 1")
+  self.hist2 = self.p:histogram("l2", "Histogram 2", {"var", "site"})
+end
+function TestPrometheus.tearDown()
+  ngx.logs = nil
+end
+function TestPrometheus:testInit()
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testInitOptions()
+  self.dict = setmetatable({}, SimpleDict)
+  ngx.shared.metrics = self.dict
+
+  local p1 = require('prometheus').init("metrics")
+  assert(p1.prefix == "")
+  assert(p1.sync_interval == 1)
+  assert(p1.error_metric_name == "nginx_metric_errors_total")
+
+  local p2 = require('prometheus').init("metrics", "test_pref_")
+  assert(p2.prefix == "test_pref_")
+  assert(p2.sync_interval == 1)
+  assert(p2.error_metric_name == "nginx_metric_errors_total")
+
+  local p3 = require('prometheus').init("metrics", {sync_interval=3})
+  assert(p3.prefix == "")
+  assert(p3.sync_interval == 3)
+  assert(p3.error_metric_name == "nginx_metric_errors_total")
+
+  local p4 = require('prometheus').init("metrics", {
+    prefix="foo", sync_interval=3, error_metric_name="foobar"})
+  assert(p4.prefix == "foo")
+  assert(p4.sync_interval == 3)
+  assert(p4.error_metric_name == "foobar")
+
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testInitWorker()
+  self.dict = setmetatable({}, SimpleDict)
+  ngx.shared.metrics = self.dict
+
+  local p1 = require('prometheus').init("metrics")
+  p1:init_worker(3)
+
+  luaunit.assertEquals(#ngx.logs, 1)
+  luaunit.assertStrContains(ngx.logs[1], "do not explicitly call init_worker")
+end
+function TestPrometheus.testErrorUnitialized()
+  local p = require('prometheus')
+  p:counter("metric1")
+  p:histogram("metric2")
+  p:gauge("metric3")
+  p:metric_data()
+
+  luaunit.assertEquals(#ngx.logs, 4)
+end
+function TestPrometheus.testErrorUnknownDict()
+  local pok, perr = pcall(require('prometheus').init, "nonexistent")
+  luaunit.assertEquals(pok, false)
+  luaunit.assertStrContains(perr, "does not seem to exist")
+end
+function TestPrometheus:testErrorNoMemory()
+  local gauge3 = self.p:gauge("willnotfit")
+  self.counter1:inc(5)
+  gauge3:inc(1)
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get("metric1"), 5)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+  luaunit.assertEquals(self.dict:get("willnotfit"), nil)
+  luaunit.assertEquals(#ngx.logs, 1)
+end
+function TestPrometheus:testErrorInvalidMetricName()
+  self.p:histogram("name with a space", "Histogram")
+  self.p:gauge("nonprintable\004characters", "Gauge")
+  self.p:counter("0startswithadigit", "Counter")
+  self.p:counter("__ngx_prom__usesinternalprefix", "Counter no.2")
+
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 4)
+  luaunit.assertEquals(#ngx.logs, 4)
+end
+function TestPrometheus:testErrorInvalidLabels()
+  self.p:histogram("hist1", "Histogram", {"le"})
+  self.p:gauge("count1", "Gauge", {"le"})
+  self.p:counter("count1", "Counter", {"foo\002"})
+
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 3)
+  luaunit.assertEquals(#ngx.logs, 3)
+end
+function TestPrometheus:testErrorDuplicateMetrics()
+  self.p:counter("metric1", "Another metric 1")
+  self.p:counter("l1_count", "Conflicts with Histogram 1")
+  self.p:counter("l2_sum", "Conflicts with Histogram 2")
+  self.p:counter("l2_bucket", "Conflicts with Histogram 2")
+  self.p:gauge("metric1", "Conflicts with Metric 1")
+  self.p:histogram("l1", "Conflicts with Histogram 1")
+  self.p:histogram("metric2", "Conflicts with Metric 2")
+  self.p:counter("metric_A_count", "Metric ending with _count")
+  self.p:histogram("metric_A", "Conflicts with metric_A_count")
+  self.p:counter("metric_B_sum", "Metric ending with _sum")
+  self.p:histogram("metric_B", "Conflicts with metric_B_sum")
+  self.p:counter("metric_C_bucket", "Metric ending with _bucket")
+  self.p:histogram("metric_C", "Conflicts with metric_C_bucket")
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 10)
+  luaunit.assertEquals(#ngx.logs, 10)
+end
+function TestPrometheus:testErrorNegativeValue()
+  self.counter1:inc(-5)
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get("metric1"), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+  luaunit.assertEquals(#ngx.logs, 1)
+end
+function TestPrometheus:testErrorIncorrectLabels()
+  self.counter1:inc(1, {"should-be-no-labels"})
+  self.counter2:inc(1, {"too-few-labels"})
+  self.counter2:inc(1, {nil, "v"})
+  self.counter2:inc(1, {"v", nil})
+  self.counter2:inc(1)
+  self.counter3:inc(1, {nil})
+  self.gauge1:set(1, {"should-be-no-labels"})
+  self.gauge2:set(1, {"too-few-labels"})
+  self.gauge2:set(1)
+  self.hist2:observe(1, {"too", "many", "labels"})
+  self.hist2:observe(1, {nil, "label"})
+  self.hist2:observe(1, {"label", nil})
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get("metric1"), nil)
+  luaunit.assertEquals(self.dict:get("l1_count"), nil)
+  luaunit.assertEquals(self.dict:get("gauge1"), nil)
+  luaunit.assertEquals(self.dict:get("gauge2"), nil)
+  luaunit.assertEquals(self.dict:get("l1_count"), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 12)
+  luaunit.assertEquals(#ngx.logs, 12)
+end
+function TestPrometheus:testNumericLabelValues()
+  self.counter2:inc(1, {0, 15.5})
+  self.gauge2:set(1, {0, 15.5})
+  self.hist2:observe(1, {-3, 90000})
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get('metric2{f2="0",f1="15.5"}'), 1)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="0",f1="15.5"}'), 1)
+  luaunit.assertEquals(self.dict:get('l2_sum{var="-3",site="90000"}'), 1)
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testNonPrintableLabelValues()
+  self.counter2:inc(1, {"foo", "baz\189\166qux"})
+  self.gauge2:set(1, {"z\001", "\002"})
+  self.hist2:observe(1, {"\166omg", "fooшbar"})
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get('metric2{f2="foo",f1="bazqux"}'), 1)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="z",f1=""}'), 1)
+  luaunit.assertEquals(self.dict:get('l2_sum{var="omg",site="foobar"}'), 1)
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testNoValues()
+  self.counter1:inc()  -- defaults to 1
+  self.gauge1:set()  -- should produce an error
+  self.hist1:observe()  -- should produce an error
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get("metric1"), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 2)
+  luaunit.assertEquals(#ngx.logs, 2)
+end
+function TestPrometheus:testCounters()
+  self.counter1:inc()
+  self.counter1:inc(4)
+  self.counter2:inc(1, {"v2", "v1"})
+  self.counter2:inc(3, {"v2", "v1"})
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get("metric1"), 5)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v1"}'), 4)
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testGaugeIncDec()
+  self.gauge1:inc(-1)
+  luaunit.assertEquals(self.dict:get("gauge1"), -1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge1:inc(3)
+  luaunit.assertEquals(self.dict:get("gauge1"), 2)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge1:inc()
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:inc(1, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:inc(5, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 6)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="othervalue"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:inc(-2, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 4)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:inc(-5, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge1:inc(1, {"should-be-no-labels"})
+  self.gauge2:inc(1, {"too-few-labels"})
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 2)
+end
+function TestPrometheus:testGaugeDel()
+  self.gauge1:inc(1)
+  luaunit.assertEquals(self.dict:get("gauge1"), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge1:del()
+  luaunit.assertEquals(self.dict:get("gauge1"), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:inc(1, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:del({"f2value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+
+  self.gauge2:del({"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+end
+function TestPrometheus:testCounterDel()
+  self.counter1:inc(1)
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get("metric1"), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter1:del()
+  luaunit.assertEquals(self.dict:get("metric1"), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter2:inc(1, {"f2value", "f1value"})
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get('metric2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter2:del()
+  luaunit.assertEquals(self.dict:get('metric2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+
+  self.counter2:del({"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('metric2{f2="f2value",f1="f1value"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+end
+function TestPrometheus:testReset()
+  self.gauge1:inc(1)
+  luaunit.assertEquals(self.dict:get("gauge1"), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge1:reset()
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get("gauge1"), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge1:inc(3)
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:inc(1, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:inc(4, {"f2value", "f1value2"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value2"}'), 4)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:reset()
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), nil)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value2"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter1:inc()
+  self.counter1:inc(4)
+  self.counter2:inc(1, {"v2", "v1"})
+  self.counter2:inc(3, {"v2", "v2"})
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get("metric1"), 5)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v1"}'), 1)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v2"}'), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter1:reset()
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get("metric1"), nil)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v1"}'), 1)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v2"}'), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter1:inc(4)
+  self.p._counter:sync()
+  self.counter2:reset()
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get("metric1"), 4)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v1"}'), nil)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v2"}'), nil)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), nil)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value2"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  -- key not exist
+  self.gauge2:inc(4, {"key_not_exist", "key_not_exist"})
+  self.gauge2:reset()
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get('gauge2{f2="key_not_exist",f1="key_not_exist"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  -- error get from dict
+  self.gauge2:inc(4, {"dict_error", "dict_error"})
+  self.gauge2:reset()
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get('gauge2{f2="dict_error",f1="dict_error"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+end
+function TestPrometheus:testLatencyHistogram()
+  self.hist1:observe(0.35)
+  self.hist1:observe(0.4)
+  self.hist2:observe(0.001, {"ok", "site1"})
+  self.hist2:observe(0.15, {"ok", "site1"})
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get('l1_bucket{le="00.300"}'), nil)
+  luaunit.assertEquals(self.dict:get('l1_bucket{le="00.400"}'), 2)
+  luaunit.assertEquals(self.dict:get('l1_bucket{le="00.500"}'), 2)
+  luaunit.assertEquals(self.dict:get('l1_bucket{le="Inf"}'), 2)
+  luaunit.assertEquals(self.dict:get('l1_count'), 2)
+  luaunit.assertEquals(self.dict:get('l1_sum'), 0.75)
+  luaunit.assertEquals(self.dict:get('l2_bucket{var="ok",site="site1",le="00.005"}'), 1)
+  luaunit.assertEquals(self.dict:get('l2_bucket{var="ok",site="site1",le="00.100"}'), 1)
+  luaunit.assertEquals(self.dict:get('l2_bucket{var="ok",site="site1",le="00.200"}'), 2)
+  luaunit.assertEquals(self.dict:get('l2_bucket{var="ok",site="site1",le="Inf"}'), 2)
+  luaunit.assertEquals(self.dict:get('l2_count{var="ok",site="site1"}'), 2)
+  luaunit.assertEquals(self.dict:get('l2_sum{var="ok",site="site1"}'), 0.151)
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testLabelEscaping()
+  self.counter2:inc(1, {"v2", "\""})
+  self.counter2:inc(5, {"v2", "\\"})
+  self.gauge2:set(1, {"v2", "\""})
+  self.gauge2:set(5, {"v2", "\\"})
+  self.hist2:observe(0.001, {"ok", "site\"1"})
+  self.hist2:observe(0.15, {"ok", "site\"1"})
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="\\""}'), 1)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="\\\\"}'), 5)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="v2",f1="\\""}'), 1)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="v2",f1="\\\\"}'), 5)
+  luaunit.assertEquals(self.dict:get('l2_bucket{var="ok",site="site\\"1",le="00.005"}'), 1)
+  luaunit.assertEquals(self.dict:get('l2_bucket{var="ok",site="site\\"1",le="00.100"}'), 1)
+  luaunit.assertEquals(self.dict:get('l2_bucket{var="ok",site="site\\"1",le="00.200"}'), 2)
+  luaunit.assertEquals(self.dict:get('l2_bucket{var="ok",site="site\\"1",le="Inf"}'), 2)
+  luaunit.assertEquals(self.dict:get('l2_count{var="ok",site="site\\"1"}'), 2)
+  luaunit.assertEquals(self.dict:get('l2_sum{var="ok",site="site\\"1"}'), 0.151)
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testCustomBucketer1()
+  local hist3 = self.p:histogram("l3", "Histogram 3", {"var"}, {1,2,3})
+  self.hist1:observe(0.35)
+  hist3:observe(2, {"ok"})
+  hist3:observe(0.151, {"ok"})
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get('l1_bucket{le="00.300"}'), nil)
+  luaunit.assertEquals(self.dict:get('l1_bucket{le="00.400"}'), 1)
+  luaunit.assertEquals(self.dict:get('l3_bucket{var="ok",le="1.0"}'), 1)
+  luaunit.assertEquals(self.dict:get('l3_bucket{var="ok",le="2.0"}'), 2)
+  luaunit.assertEquals(self.dict:get('l3_bucket{var="ok",le="3.0"}'), 2)
+  luaunit.assertEquals(self.dict:get('l3_bucket{var="ok",le="Inf"}'), 2)
+  luaunit.assertEquals(self.dict:get('l3_count{var="ok"}'), 2)
+  luaunit.assertEquals(self.dict:get('l3_sum{var="ok"}'), 2.151)
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testCustomBucketer2()
+  local hist3 = self.p:histogram("l3", "Histogram 3", {"var"},
+    {0.000005,5,50000})
+  hist3:observe(0.000001, {"ok"})
+  hist3:observe(3, {"ok"})
+  hist3:observe(7, {"ok"})
+  hist3:observe(70000, {"ok"})
+
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get('l3_bucket{var="ok",le="00000.000005"}'), 1)
+  luaunit.assertEquals(self.dict:get('l3_bucket{var="ok",le="00005.000000"}'), 2)
+  luaunit.assertEquals(self.dict:get('l3_bucket{var="ok",le="50000.000000"}'), 3)
+  luaunit.assertEquals(self.dict:get('l3_bucket{var="ok",le="Inf"}'), 4)
+  luaunit.assertEquals(self.dict:get('l3_count{var="ok"}'), 4)
+  luaunit.assertEquals(self.dict:get('l3_sum{var="ok"}'), 70010.000001)
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testCollect()
+  local hist3 = self.p:histogram("b1", "Bytes", {"var"}, {100, 2000})
+  self.counter1:inc(5)
+  self.counter2:inc(2, {"v2", "v1"})
+  self.counter2:inc(2, {"v2", "v1"})
+  self.gauge1:set(3)
+  self.gauge2:set(2, {"v2", "v1"})
+  self.gauge2:set(5, {"v2", "v1"})
+  self.hist1:observe(0.000001)
+  self.hist2:observe(0.000001, {"ok", "site2"})
+  self.hist2:observe(3, {"ok", "site2"})
+  self.hist2:observe(7, {"ok", "site2"})
+  self.hist2:observe(70000, {"ok","site2"})
+  hist3:observe(50, {"ok"})
+  hist3:observe(50, {"ok"})
+  hist3:observe(150, {"ok"})
+  hist3:observe(5000, {"ok"})
+  self.p:collect()
+
+  assert(find_idx(ngx.printed, "# HELP metric1 Metric 1") ~= nil)
+  assert(find_idx(ngx.printed, "# TYPE metric1 counter") ~= nil)
+  assert(find_idx(ngx.printed, "metric1 5") ~= nil)
+
+  assert(find_idx(ngx.printed, "# TYPE metric2 counter") ~= nil)
+  assert(find_idx(ngx.printed, 'metric2{f2="v2",f1="v1"} 4') ~= nil)
+
+  assert(find_idx(ngx.printed, "# TYPE gauge1 gauge") ~= nil)
+  assert(find_idx(ngx.printed, 'gauge1 3') ~= nil)
+
+  assert(find_idx(ngx.printed, "# TYPE gauge2 gauge") ~= nil)
+  assert(find_idx(ngx.printed, 'gauge2{f2="v2",f1="v1"} 5') ~= nil)
+
+  assert(find_idx(ngx.printed, "# TYPE b1 histogram") ~= nil)
+  assert(find_idx(ngx.printed, "# HELP b1 Bytes") ~= nil)
+  assert(find_idx(ngx.printed, 'b1_bucket{var="ok",le="0100.0"} 2') ~= nil)
+  assert(find_idx(ngx.printed, 'b1_sum{var="ok"} 5250') ~= nil)
+
+  assert(find_idx(ngx.printed, 'l2_bucket{var="ok",site="site2",le="04.000"} 2') ~= nil)
+  assert(find_idx(ngx.printed, 'l2_bucket{var="ok",site="site2",le="+Inf"} 4') ~= nil)
+
+  -- check that type comment exists and is before any samples for the metric.
+  local type_idx = find_idx(ngx.printed, '# TYPE l1 histogram')
+  assert (type_idx ~= nil)
+  assert (ngx.printed[type_idx-1]:find("^l1") == nil)
+  assert (ngx.printed[type_idx+1]:find("^l1") ~= nil)
+  luaunit.assertEquals(ngx.logs, nil)
+end
+
+function TestPrometheus:testCollectWithPrefix()
+  self.dict = setmetatable({}, SimpleDict)
+  ngx.shared.metrics = self.dict
+  local p = require('prometheus').init("metrics", "test_pref_")
+
+  local counter1 = p:counter("metric1", "Metric 1")
+  local gauge1 = p:gauge("gauge1", "Gauge 1")
+  local hist1 = p:histogram("b1", "Bytes", {"var"}, {100, 2000})
+  counter1:inc(5)
+  gauge1:set(3)
+  hist1:observe(50, {"ok"})
+  hist1:observe(50, {"ok"})
+  hist1:observe(150, {"ok"})
+  hist1:observe(5000, {"ok"})
+  p:collect()
+
+  assert(find_idx(ngx.printed, "# HELP test_pref_metric1 Metric 1") ~= nil)
+  assert(find_idx(ngx.printed, "# TYPE test_pref_metric1 counter") ~= nil)
+  assert(find_idx(ngx.printed, "test_pref_metric1 5") ~= nil)
+
+  assert(find_idx(ngx.printed, "# HELP test_pref_gauge1 Gauge 1") ~= nil)
+  assert(find_idx(ngx.printed, "# TYPE test_pref_gauge1 gauge") ~= nil)
+  assert(find_idx(ngx.printed, "test_pref_gauge1 3") ~= nil)
+
+  assert(find_idx(ngx.printed, "# TYPE test_pref_b1 histogram") ~= nil)
+  assert(find_idx(ngx.printed, "# HELP test_pref_b1 Bytes") ~= nil)
+  assert(find_idx(ngx.printed, 'test_pref_b1_bucket{var="ok",le="0100.0"} 2') ~= nil)
+  assert(find_idx(ngx.printed, 'test_pref_b1_sum{var="ok"} 5250') ~= nil)
+end
+
+TestKeyIndex = {}
+function TestKeyIndex:setUp()
+  self.dict = setmetatable({}, SimpleDict)
+  ngx.shared.metrics = self.dict
+  self.key_index = require('prometheus_keys').new(self.dict, '_prefix_')
+end
+function TestKeyIndex.tearDown()
+  ngx.logs = nil
+end
+function TestKeyIndex.testInit()
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestKeyIndex:testAdd()
+  self.key_index:add("single")
+  luaunit.assertEquals(ngx.logs, nil)
+  luaunit.assertEquals(self.dict:get("_prefix_key_count"), 1)
+  luaunit.assertEquals(self.dict:get("_prefix_key_1"), "single")
+
+  self.key_index:add({"multiple", "keys"})
+  luaunit.assertEquals(ngx.logs, nil)
+  luaunit.assertEquals(self.dict:get("_prefix_key_count"), 3)
+  luaunit.assertEquals(self.dict:get("_prefix_key_2"), "multiple")
+  luaunit.assertEquals(self.dict:get("_prefix_key_3"), "keys")
+
+  -- adding already existing key should do nothing
+  self.key_index:add("single")
+  luaunit.assertEquals(ngx.logs, nil)
+  luaunit.assertEquals(self.dict:get("_prefix_key_count"), 3)
+
+  -- error should be returned when memory is full
+  local err = self.key_index:add("willnotfit")
+  luaunit.assertEquals(err, "Unexpected error adding a key: no memory")
+  luaunit.assertEquals(self.dict:get("_prefix_key_count"), 3)
+end
+function TestKeyIndex:testRemove()
+  self.key_index:add({"key1", "key2", "key3"})
+
+  self.key_index:remove("key2")
+  luaunit.assertEquals(ngx.logs, nil)
+  luaunit.assertEquals(self.dict:get("_prefix_key_count"), 3)
+  luaunit.assertEquals(self.dict:get("_prefix_delete_count"), 1)
+  local keys = self.key_index:list()
+  luaunit.assertEquals(#keys, 2)
+  luaunit.assertEquals(keys[1], "key1")
+  luaunit.assertEquals(keys[2], "key3")
+
+  self.key_index:remove("key4")
+  luaunit.assertEquals(#ngx.logs, 1)
+  keys = self.key_index:list()
+  luaunit.assertEquals(#keys, 2)
+  luaunit.assertEquals(keys[1], "key1")
+  luaunit.assertEquals(keys[2], "key3")
+end
+function TestKeyIndex:testList()
+  self.key_index:add({"key1", "key2", "key3"})
+  local keys = self.key_index:list()
+  luaunit.assertEquals(ngx.logs, nil)
+  luaunit.assertEquals(#keys, 3)
+  luaunit.assertEquals(keys[1], "key1")
+  luaunit.assertEquals(keys[2], "key2")
+  luaunit.assertEquals(keys[3], "key3")
+end
+
+function TestKeyIndex:testSync()
+  self.key_index:sync()
+  luaunit.assertEquals(ngx.logs, nil)
+  luaunit.assertEquals(self.dict:get("_prefix_key_count"), nil)
+  luaunit.assertEquals(self.dict:get("_prefix_delete_count"), nil)
+
+  -- key added by another worker
+  self.dict:safe_set("_prefix_key_count", 1)
+  self.dict:safe_set("_prefix_key_1", "key1")
+  self.key_index:sync()
+  local keys = self.key_index:list()
+  luaunit.assertEquals(ngx.logs, nil)
+  luaunit.assertEquals(#keys, 1)
+  luaunit.assertEquals(keys[1], "key1")
+
+  -- multiple keys added by another worker
+  self.dict:safe_set("_prefix_key_count", 3)
+  self.dict:safe_set("_prefix_key_2", "key2")
+  self.dict:safe_set("_prefix_key_3", "key3")
+  self.key_index:sync()
+  keys = self.key_index:list()
+  luaunit.assertEquals(ngx.logs, nil)
+  luaunit.assertEquals(#keys, 3)
+  luaunit.assertEquals(keys[1], "key1")
+  luaunit.assertEquals(keys[2], "key2")
+  luaunit.assertEquals(keys[3], "key3")
+
+  -- key deleted by another worker
+  self.dict:safe_set("_prefix_delete_count", 1)
+  self.dict:delete("_prefix_key_2")
+  self.dict:safe_set("_prefix_key_3", "key3")
+  self.key_index:sync()
+  keys = self.key_index:list()
+  luaunit.assertEquals(ngx.logs, nil)
+  luaunit.assertEquals(#keys, 2)
+  luaunit.assertEquals(keys[1], "key1")
+  luaunit.assertEquals(keys[2], "key3")
+end
+
+os.exit(luaunit.run())

--- a/kubernetes-monitoring/ingress.yaml
+++ b/kubernetes-monitoring/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: prometheus-operator-kube-p-prometheus
+              port:
+                number: 9090
+        - path: /prometheus-exporter
+          pathType: Prefix
+          backend:
+            service:
+              name: homework-service
+              port:
+                number: 9113
+        - path: /metrics
+          pathType: Prefix
+          backend:
+            service:
+              name: homework-service
+              port:
+                number: 9113
+        - path: /prometheus
+          pathType: Prefix
+          backend:
+           service:
+             name: homework-service
+             port:
+               number: 8000

--- a/kubernetes-monitoring/service.yaml
+++ b/kubernetes-monitoring/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homework-service
+  labels:
+    app: homework-service
+spec:
+  selector:
+    app: homework-service
+  ports:
+    - name: custom-exporter
+      protocol: TCP
+      port: 8000
+      targetPort: 8000
+    - name: nginx-prometheus-exporter
+      protocol: TCP
+      port: 9113
+      targetPort: 9113

--- a/kubernetes-monitoring/servicemonitor.yaml
+++ b/kubernetes-monitoring/servicemonitor.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: web-monitoring
+  labels:
+    team: frontend
+spec:
+  selector:
+    matchLabels:
+      app: homework-service
+  endpoints:
+    - port: nginx-prometheus-exporter
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: custom-monitoring
+  labels:
+    team: frontend
+spec:
+  selector:
+    matchLabels:
+      app: homework-service
+  endpoints:
+    - port: custom-exporter
+      path: /prometheus/


### PR DESCRIPTION
# Мониторинг компонентов кластера и приложений, работающих в нем ДЗ#8

 - [*] Основное ДЗ

***Работы производим на WSL-Ubuntu***

## Подготовка окружения к ДЗ
1) Очищаем minikube от предыдущих занятий - minikube delete

2) Запустить - minikube start

3) Устанавливаем addon ingress - minikube addons enable ingress

4) Проверяем корректность активированного ingress - kubectl get pods -n ingress-nginx

5) В хостовую машину добавляем dns запись вида (в файл hosts) - 127.0.0.1 kubernetes.docker.internal homework.otus

6) Запускаем тунель - minikube tunnel


## Выполнения ДЗ

1) Устанавливаем prometheus-operator - helm install my-release oci://registry-1.docker.io/bitnamicharts/kube-prometheus

2) Создаем docker image
    - включаем модуль stab_status  
    ```
    location /metrics {
        stub_status on;
    }
    ```
    - **подключаем модуль/библиотеки prometheus для lua**
    ```
    lua_package_path "/usr/local/openresty/nginx/lualib/lib/?.lua;;";
    lua_shared_dict prometheus_metrics 10M;

    init_worker_by_lua_block {
        prometheus = require("prometheus").init("prometheus_metrics")
        metric_requests = prometheus:counter(
        "nginx_http_requests_total", "Number of HTTP requests", {"host", "status"})
        metric_latency = prometheus:histogram(
        "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
        metric_connections = prometheus:gauge(
        "nginx_http_connections", "Number of HTTP connections", {"state"})
    }

    location /prometheus {
        #access_log off;

        content_by_lua '
            metric_connections:set(ngx.var.connections_reading, {"reading"})
            metric_connections:set(ngx.var.connections_waiting, {"waiting"})
            metric_connections:set(ngx.var.connections_writing, {"writing"})
            prometheus:collect()
        ';
    }

    ```  
    - Собираем образ и отправляем в публичный репозиторий -
    ```bash
    docker build -t nvtikhomirov/openresty-prometheus:v0.0.3 .
    docker push nvtikhomirov/openresty-prometheus:v0.0.3    
    ```

3) Создаем файл deployment.yaml (nginx-prometheus-exporter собирает метрики с /metrics, готовые метрики /prometheus)

4) Создаем service и servicemonitor.yaml

5) Для удобства создаем ingress:

    - /metrics (/prometheus-exporter) для работы с nginx-prometheus-exporter

    - / - вывод prometheus

    - /prometheus - метрики сгенерированые lua

6) Проверка

    - переходим в Targets, находим ранее созданые точки мониторинга: serviceMonitor/default/custom-monitoring, serviceMonitor/default/web-monitoring (статус UP)

    - производим выборочную проверку метрик nginx


## Как проверить работоспособность:
 - http://homework.otus/metrics
 - http://homework.otus/targets?search=
 - http://homework.otus/graph?g0.expr=nginx_http_connections&g0.tab=0&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=1h

## PR checklist:
 - [*] Выставлен label с темой домашнего задания
